### PR TITLE
prima: overwrite mac address if config file exists

### DIFF
--- a/drivers/staging/prima/CORE/HDD/inc/wlan_hdd_cfg.h
+++ b/drivers/staging/prima/CORE/HDD/inc/wlan_hdd_cfg.h
@@ -3794,6 +3794,7 @@ typedef struct
   Function declarations and documenation
   -------------------------------------------------------------------------*/ 
 VOS_STATUS hdd_parse_config_ini(hdd_context_t *pHddCtx);
+VOS_STATUS hdd_update_mac_config(hdd_context_t *pHddCtx);
 VOS_STATUS hdd_set_sme_config( hdd_context_t *pHddCtx );
 v_BOOL_t hdd_update_config_dat ( hdd_context_t *pHddCtx );
 VOS_STATUS hdd_cfg_get_config(hdd_context_t *pHddCtx, char *pBuf, int buflen);

--- a/drivers/staging/prima/CORE/HDD/src/wlan_hdd_cfg.c
+++ b/drivers/staging/prima/CORE/HDD/src/wlan_hdd_cfg.c
@@ -4066,6 +4066,133 @@ typedef struct
    char *value;
 }tCfgIniEntry;
 
+
+/* convert string to 6 bytes mac address
+ * 00AA00BB00CC -> 0x00 0xAA 0x00 0xBB 0x00 0xCC
+ */
+static void update_mac_from_string(hdd_context_t *pHddCtx, tCfgIniEntry *macTable, int num)
+{
+   int i = 0, j = 0, res = 0;
+   char *candidate = NULL;
+   v_MACADDR_t macaddr[VOS_MAX_CONCURRENCY_PERSONA];
+
+   memset(macaddr, 0, sizeof(macaddr));
+
+   for (i = 0; i < num; i++)
+   {
+      candidate = macTable[i].value;
+      for (j = 0; j < VOS_MAC_ADDR_SIZE; j++) {
+         res = hex2bin(&macaddr[i].bytes[j], &candidate[(j<<1)], 1);
+         if (res < 0)
+            break;
+      }
+      if (res == 0 && !vos_is_macaddr_zero(&macaddr[i])) {
+         vos_mem_copy((v_U8_t *)&pHddCtx->cfg_ini->intfMacAddr[i].bytes[0],
+                      (v_U8_t *)&macaddr[i].bytes[0], VOS_MAC_ADDR_SIZE);
+      }
+   }
+}
+
+/*
+ * This function tries to update mac address from cfg file.
+ * It overwrites the MAC address if config file exist.
+ */
+VOS_STATUS hdd_update_mac_config(hdd_context_t *pHddCtx)
+{
+   int status, i = 0, j = 0;
+   char * buf;
+   const struct firmware *fw = NULL;
+   const char prefix[] = "Intf";
+   const char suffix[] = "MacAddress";
+   tCfgIniEntry macTable[VOS_MAX_CONCURRENCY_PERSONA];
+   VOS_STATUS vos_status = VOS_STATUS_SUCCESS;
+
+   // make sure all pointers in macTable are NULL, so an early jump to config_exit will not crash
+   memset(macTable, 0, sizeof(macTable));
+
+   status = request_firmware(&fw, WLAN_MAC_FILE, pHddCtx->parent_dev);
+
+   if (status)
+   {
+      hddLog(VOS_TRACE_LEVEL_WARN, "%s: request_firmware failed %d",
+             __func__, status);
+      return VOS_STATUS_E_FAILURE;
+   }
+   if (fw == NULL || fw->data == NULL || fw->size < (VOS_MAX_CONCURRENCY_PERSONA * NV_FIELD_MAC_ADDR_SIZE))
+   {
+      hddLog(VOS_TRACE_LEVEL_FATAL, "%s: invalid firmware", __func__);
+      release_firmware(fw);
+      return VOS_STATUS_E_INVAL;
+   }
+
+   /* data format:
+    * 00AA00BB00CA00AA00BB00CB00AA00BB00CC00AA00BB00CD
+    */
+
+   for (i = 0; i < VOS_MAX_CONCURRENCY_PERSONA; i++)
+   {
+      int lenPersona = snprintf(NULL, 0, "%d", i);
+
+      char *persona = (char*)vos_mem_vmalloc(lenPersona + 1);
+      if (NULL == persona) {
+         hddLog(VOS_TRACE_LEVEL_FATAL, "%s: kmalloc failure", __func__);
+         vos_status = VOS_STATUS_E_FAILURE;
+         goto config_exit;
+      }
+
+      macTable[i].name = (char*)vos_mem_vmalloc((sizeof(prefix) - 1) + lenPersona + (sizeof(suffix) - 1) + 1);
+      if (NULL == macTable[i].name) {
+         hddLog(VOS_TRACE_LEVEL_FATAL, "%s: kmalloc failure", __func__);
+         vos_status = VOS_STATUS_E_FAILURE;
+         vos_mem_vfree(persona);
+         goto config_exit;
+      }
+
+      macTable[i].value = (char*)vos_mem_vmalloc(NV_FIELD_MAC_ADDR_SIZE * 2 + 1);
+      if (NULL == macTable[i].value) {
+         hddLog(VOS_TRACE_LEVEL_FATAL, "%s: kmalloc failure", __func__);
+         vos_status = VOS_STATUS_E_FAILURE;
+         vos_mem_vfree(persona);
+         goto config_exit;
+      }
+
+      sprintf(persona, "%d", i);
+
+      strcpy(macTable[i].name, prefix);
+      strcat(macTable[i].name, persona);
+      strcat(macTable[i].name, suffix);
+
+      buf = macTable[i].value;
+      for (j = 0; j < NV_FIELD_MAC_ADDR_SIZE; j++)
+      {
+         buf += sprintf(buf, "%02X", fw->data[NV_FIELD_MAC_ADDR_SIZE * i + j]);
+      }
+
+      vos_mem_vfree(persona);
+   }
+
+   if (i <= VOS_MAX_CONCURRENCY_PERSONA) {
+      hddLog(VOS_TRACE_LEVEL_INFO, "%s: %d MAC addresses provided", __func__, i);
+   }
+   else {
+      hddLog(VOS_TRACE_LEVEL_ERROR, "%s: invalid number of MAC address provided, nMac = %d",
+             __func__, i);
+      vos_status = VOS_STATUS_E_INVAL;
+      goto config_exit;
+   }
+
+   update_mac_from_string(pHddCtx, &macTable[0], i);
+
+config_exit:
+   for(i = 0; i < VOS_MAX_CONCURRENCY_PERSONA; i++)
+   {
+      vos_mem_vfree(macTable[i].name);
+      vos_mem_vfree(macTable[i].value);
+   }
+   release_firmware(fw);
+   return vos_status;
+}
+
 static VOS_STATUS hdd_apply_cfg_ini( hdd_context_t * pHddCtx,
     tCfgIniEntry* iniTable, unsigned long entries);
 

--- a/drivers/staging/prima/CORE/HDD/src/wlan_hdd_main.c
+++ b/drivers/staging/prima/CORE/HDD/src/wlan_hdd_main.c
@@ -12887,6 +12887,22 @@ int hdd_wlan_startup(struct device *dev )
    {
       eHalStatus halStatus;
 
+      /* Overwrite the Mac address if config file exist */
+      if (VOS_STATUS_SUCCESS != hdd_update_mac_config(pHddCtx))
+      {
+         hddLog(VOS_TRACE_LEVEL_WARN,
+                "%s: Didn't overwrite MAC from config file",
+                __func__);
+      } else {
+         pr_info("%s: WLAN Mac Addr from config: %02X:%02X:%02X:%02X:%02X:%02X\n", WLAN_MODULE_NAME,
+                 pHddCtx->cfg_ini->intfMacAddr[0].bytes[0],
+                 pHddCtx->cfg_ini->intfMacAddr[0].bytes[1],
+                 pHddCtx->cfg_ini->intfMacAddr[0].bytes[2],
+                 pHddCtx->cfg_ini->intfMacAddr[0].bytes[3],
+                 pHddCtx->cfg_ini->intfMacAddr[0].bytes[4],
+                 pHddCtx->cfg_ini->intfMacAddr[0].bytes[5]);
+      }
+
       /* Set the MAC Address Currently this is used by HAL to
        * add self sta. Remove this once self sta is added as
        * part of session open.

--- a/drivers/staging/prima/CORE/VOSS/inc/wlan_hdd_misc.h
+++ b/drivers/staging/prima/CORE/VOSS/inc/wlan_hdd_misc.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2012-2014 The Linux Foundation. All rights reserved.
+ * Copyright (c) 2017 The LineageOS Project.
  *
  * Previously licensed under the ISC license by Qualcomm Atheros, Inc.
  *
@@ -56,6 +57,7 @@
 #define WLAN_HO_CFG_FILE           "wlan/wlan_ho_config"
 #endif // MSM_PLATFORM
 
+#define WLAN_MAC_FILE              "wlan/prima/wlan_mac.bin"
 
 VOS_STATUS hdd_request_firmware(char *pfileName,v_VOID_t *pCtx,v_VOID_t **ppfw_data, v_SIZE_t *pSize);
 


### PR DESCRIPTION
Modified from qcacld-2.0
https://source.codeaurora.org/quic/la/platform/vendor/qcom-opensource/wlan/qcacld-2.0/tree/CORE/HDD/src/wlan_hdd_main.c?h=LA.BR.1.3.6.c1-00810-8976.0

Change-Id: Ie1b7fb4e8a37595786c15a444d4e588cf0fdb58a